### PR TITLE
Use the rails@4.2 default web console

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,7 @@ group :development, :test do
   gem 'pry-rails'
   gem 'spring'
   gem 'awesome_print'
-  gem 'better_errors'
-  gem 'binding_of_caller' #<- allows repl from the better_errors page
+  gem 'web-console'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,10 +40,6 @@ GEM
     autoprefixer-rails (2.1.1.20140710)
       execjs
     awesome_print (1.2.0)
-    better_errors (2.1.1)
-      coderay (>= 1.0.0)
-      erubis (>= 2.6.6)
-      rack (>= 0.9.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     bootstrap-sass (3.2.0.0)
@@ -174,6 +170,11 @@ GEM
       rack
       raindrops (~> 0.7)
     uniform_notifier (1.6.2)
+    web-console (2.0.0)
+      activemodel (~> 4.0)
+      binding_of_caller (>= 0.7.2)
+      railties (~> 4.0)
+      sprockets-rails (>= 2.0, < 4.0)
 
 PLATFORMS
   ruby
@@ -181,8 +182,6 @@ PLATFORMS
 DEPENDENCIES
   autoprefixer-rails
   awesome_print
-  better_errors
-  binding_of_caller
   bootstrap-sass
   bullet
   coffee-rails (~> 4.0.0)
@@ -200,3 +199,4 @@ DEPENDENCIES
   spring
   uglifier (>= 1.3.0)
   unicorn
+  web-console


### PR DESCRIPTION
Replaces better_errors and its console; @andrewvida tipped me off to this

very cool:

![screen shot 2015-02-14 at 6 02 50 pm](https://cloud.githubusercontent.com/assets/79303/6201379/d1902484-b473-11e4-80df-757e240fc085.png)

Adding `console` to any controller or `<%= console %>` from any erb will also add a repl to the page: 

![screen shot 2015-02-14 at 6 02 26 pm](https://cloud.githubusercontent.com/assets/79303/6201380/d348dad2-b473-11e4-8bbc-2dd87605b405.png)
