### PR TITLE
Accept project notes on non-invoice weeks

### DIFF
--- a/app/models/present/harvest/line_items.rb
+++ b/app/models/present/harvest/line_items.rb
@@ -28,8 +28,8 @@ module Present::Harvest
 
     def self.description_for(project, user, entries)
       description = user.name
-      if project.requires_notes? && projects_timesheet = entries.map(&:projects_timesheet).find(&:notes?)
-        description += "\n\n#{projects_timesheet.notes}"
+      if project.requires_notes?
+        description += "\n\n#{description_of_notes_for(entries)}"
       end
       if project.weekly?
         description += "\n\n"
@@ -41,6 +41,10 @@ module Present::Harvest
         TEXT
       end
       description
+    end
+
+    def self.description_of_notes_for(entries)
+      entries.sort_by(&:time).map(&:projects_timesheet).uniq.map(&:notes).join("\n\n").strip
     end
 
     def self.description_of_absences_for(entries)

--- a/app/views/weeks/show.html.erb
+++ b/app/views/weeks/show.html.erb
@@ -147,7 +147,7 @@
                   <%= project_fields.check_box :_destroy, :disabled => locked? unless project.sticky? %>
                 </td>
               </tr>
-              <% if @week.invoice_week? && project.requires_notes? %>
+              <% if project.requires_notes? %>
                 <%= f.fields_for :projects_timesheets, projects_timesheet do |projects_timesheet_fields| %>
                   <tr>
                     <td>


### PR DESCRIPTION
When we generate the invoices, just concatenate the notes together,
in order with a space between them.

Caveat: notes may render out of order in the invoice preview page but
will be sorted before being sent to harvest 

This fixes #61 for now