### PR TITLE
Isolating Present::Invoice translation for Harvest.

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -18,11 +18,11 @@ class InvoicesController < ApplicationController
   end
 
   def create
-    redirect_to @invoice.active_record_invoice
+    redirect_to @invoice
   end
 
   def update
-    redirect_to @invoice.active_record_invoice
+    redirect_to @invoice
   end
 
   def show
@@ -31,18 +31,18 @@ class InvoicesController < ApplicationController
   def send_to_harvest
     Present::Harvest::SendInvoice.new.send!(@invoice)
     flash[:info] = ["Sent invoice to Harvest!"]
-    redirect_to @invoice.active_record_invoice
+    redirect_to @invoice
   end
 
 private
 
   def generate_invoice_from_params
     @invoice = if params[:id].present?
-      Invoice.find(params[:id]).generate_for_harvest
+      Invoice.find(params[:id])
     else
       week = Week.new(Time.zone.parse(params[:invoice][:invoicing_week]))
       project = Project.find(params[:invoice][:project_id])
-      Invoice.find_or_create_by(week.ymd_hash.merge(:project => project)).generate_for_harvest
+      Invoice.find_or_create_by(week.ymd_hash.merge(:project => project))
     end
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -15,7 +15,15 @@ class Invoice < ActiveRecord::Base
     invoicing_week.previous
   end
 
-  def generate_for_harvest
-    Present::Harvest::GeneratedInvoice.new(self)
+  def timesheets
+    find_projects_timesheets.map(&:timesheet).uniq
   end
+
+  private
+    def find_projects_timesheets
+      ( ProjectsTimesheet.for_week_and_project(self.prior_week, self.project) +
+        ProjectsTimesheet.for_week_and_project(self.invoicing_week, self.project)
+      ).reject {|pt| pt.timesheet.empty? }
+    end
+
 end

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -46,7 +46,7 @@
   <% end %>
   <div class="breather-top row">
     <div class="text-right">
-      <%= form_for @invoice.active_record_invoice, :url => send_invoice_to_harvest_path(@invoice.id) do |f| %>
+      <%= form_for @invoice, :url => send_invoice_to_harvest_path(@invoice.id) do |f| %>
         <%= f.submit 'Send invoice to Harvest', :class => "btn btn-default" %>
         <% if @invoice.harvest_id.present? %>
           <%= link_to "https://#{Rails.application.config.harvest.subdomain}.harvestapp.com/invoices/#{@invoice.harvest_id}" do %>


### PR DESCRIPTION
  Prior to creating an adapter layer for a BillingSystem, it appears
  necessary to create a more clear distinction between a
  Present::Invoice and a BillingSystem::Invoice.  Currently there is a
  translation from an Invoice into a GeneratedInvoice which is then used
  to create a Harvest::Invoice.  The purpose of this change is to
  isolate that translation dependency down to the service layer which
  can then delegate it down to a billing system later.