### PR TITLE
Don’t blow up when missing email or user types

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,12 +1,13 @@
 <div class="users index">
   <% [:double_agents, :special_agents, :sleeper_agents].map { |g| [g, @grouped_users[g]]}.each do |(group, users)| %>
+    <% next unless users.present? %>
     <div class="group">
       <%= group.to_s.titleize %>
     </div>
     <% users.each do |user| %>
       <div class="user-profile">
         <div class="photo">
-          <img src="https://secure.gravatar.com/avatar/<%= Digest::MD5.new.hexdigest(user.github_account.email.try(:downcase)) %>?s=200"></img>
+          <img src="https://secure.gravatar.com/avatar/<%= Digest::MD5.new.hexdigest(user.github_account.email.try(:downcase) || "") %>?s=200"></img>
         </div>
         <div class="info">
           <div class="name">


### PR DESCRIPTION
For a new database, we noticed that unless all three types of users are present, you’ll encounter a nil error for `users` on the agent roster page. Additionally, if any agent is missing an e-mail, the page will fail to render (this is a common problem, because by default github does not share e-mail addresses with OAuth apps anymore)